### PR TITLE
Various bug fixes, one critical (opt-in roles broken)

### DIFF
--- a/.cobalt
+++ b/.cobalt
@@ -1,2 +1,2 @@
 This file exists for validation when using runme.rb
-update
+update2

--- a/.cobalt
+++ b/.cobalt
@@ -1,0 +1,1 @@
+This file exists for validation when using runme.rb

--- a/.cobalt
+++ b/.cobalt
@@ -1,1 +1,2 @@
 This file exists for validation when using runme.rb
+update

--- a/Rakefile
+++ b/Rakefile
@@ -38,6 +38,33 @@ namespace :run do
       system("ruby bot.rb main dev")
     end
   end
+
+  desc 'Do a dry run of the bot with the main crystals'
+  task :dryrunmain => ['dependencies'] do |event|
+    # Changes director to src
+    Dir.chdir('src') do
+      # Runs the main bot script with main and dev argument
+      system("ruby bot.rb main dryrun")
+    end
+  end
+
+  desc 'Do a dry run of the bot with the dev crystals'
+  task :dryrundev => ['dependencies'] do |event|
+    # Changes director to src
+    Dir.chdir('src') do
+      # Runs the main bot script with main and dev argument
+      system("ruby bot.rb main dev dryrun")
+    end
+  end
+
+  desc 'Do a dry run of the bot with all of the crystals (main and dev)'
+  task :dryrunall => ['dependencies'] do |event|
+    # Changes director to src
+    Dir.chdir('src') do
+      # Runs the main bot script with main and dev argument
+      system("ruby bot.rb main dev dryrun")
+    end
+  end
 end
 
 desc 'Remove git repository files'

--- a/src/bot.rb
+++ b/src/bot.rb
@@ -8,6 +8,7 @@ require 'yaml'
 # All individual crystals will be submodules of this; this gives them access to the main 
 # bot object through a constant, as well as a constant containing the path to the data folder
 module Bot
+  breakme
   # Loads config file into struct and parses info into a format readable by CommandBot constructor
   config = OpenStruct.new(YAML.load_file '../config.yml')
   config.client_id = config.id

--- a/src/bot.rb
+++ b/src/bot.rb
@@ -8,7 +8,6 @@ require 'yaml'
 # All individual crystals will be submodules of this; this gives them access to the main 
 # bot object through a constant, as well as a constant containing the path to the data folder
 module Bot
-  breakme
   # Loads config file into struct and parses info into a format readable by CommandBot constructor
   config = OpenStruct.new(YAML.load_file '../config.yml')
   config.client_id = config.id
@@ -113,6 +112,10 @@ module Bot
   puts "Starting bot with logging mode #{config.log_mode.to_s}..."
   BOT.ready { puts 'Bot started!' }
 
-  # After loading all desired crystals, runs the bot
-  BOT.run
+  unless ARGV.include? 'dryrun' # we don't actually run in dry run mode
+    # After loading all desired crystals, runs the bot
+    BOT.run
+  else
+    puts 'dryrun complete'
+  end
 end

--- a/src/bot.rb
+++ b/src/bot.rb
@@ -14,7 +14,7 @@ module Bot
   config.delete_field(:id)
   config.type = (config.type == 'user') ? :user : :bot
   config.parse_self = !!config.react_to_self
-  confhi2ij2rjio23jiig.delete_field(:react_to_self)
+  config.delete_field(:react_to_self)
   config.help_command = config.help_alias || false
   config.delete_field(:help_alias)
   config.spaces_allowed = config.spaces_allowed.class == TrueClass

--- a/src/bot.rb
+++ b/src/bot.rb
@@ -14,7 +14,7 @@ module Bot
   config.delete_field(:id)
   config.type = (config.type == 'user') ? :user : :bot
   config.parse_self = !!config.react_to_self
-  config.delete_field(:react_to_self)
+  confhi2ij2rjio23jiig.delete_field(:react_to_self)
   config.help_command = config.help_alias || false
   config.delete_field(:help_alias)
   config.spaces_allowed = config.spaces_allowed.class == TrueClass

--- a/src/dev/custom_commands.rb
+++ b/src/dev/custom_commands.rb
@@ -145,13 +145,12 @@ module Bot::CustomCommands
   # @return [bool] Success? Returns false if command already exists or name/content is too long.
   # Note: Must link to a created item.
   def AddCustomCommand(command_name, owner_user_id, item_entry_id, command_content)
+    command_name = command_name.downcase # enforce lowercase command naems
     return false if command_name.length <= 0 or command_name.length > GetMaxCustomCommandNameLength() or command_content.length > GetMaxCustomCommandContentLength()
     return false if command_name =~ /\s/ # no spaces allowed
     return false if USER_CUSTOM_COMMANDS.where{Sequel.&({command_name: command_name}, {owner_user_id: owner_user_id})}.count() > 0
 
-    # enforce lowercase command naems
-    command_name = command_name.downcase
-
+    
     # will raise error on invalid content
     USER_CUSTOM_COMMANDS << { command_name: command_name, owner_user_id: owner_user_id, item_entry_id: item_entry_id, command_content: command_content }
     return true

--- a/src/dev/economy.rb
+++ b/src/dev/economy.rb
@@ -313,6 +313,7 @@ module Bot::Economy
   SETTIMEZONE_DESCRIPTION = "Set your timezone.\nSee https://en.wikipedia.org/wiki/List_of_tz_database_time_zones for a list of valid values."
   SETTIMEZONE_ARGS = [["timezone_name", String]]
   SETTIMEZONE_REQ_COUNT = 1
+  # TODO: make this accept spaces by using arg=''
   command :settimezone do |event, *args|
     # parse args
     opt_defaults = []

--- a/src/helper/tags.rb
+++ b/src/helper/tags.rb
@@ -86,13 +86,11 @@ module Bot::Tags
   # @return [bool] Success? Returns false if tag already exists or name is invalid
   # Note: Must link to a created item.
   def AddTag(tag_name, item_entry_id, owner_user_id, tag_content)
+    tag_name = tag_name.downcase #enforce lowercase names
     return false if tag_name.length <= 0 or tag_name.length > GetMaxTagNameLength() or tag_content.length > GetMaxTagContentLength()
     return false if tag_name =~ /\s/ # no spaces allowed
     return false if USER_TAGS.where(tag_name: tag_name).count() > 0
     
-    #enforce lowercase names
-    tag_name = tag_name.downcase
-
     # will raise error on invalid content
     USER_TAGS << { item_entry_id: item_entry_id, owner_user_id: owner_user_id, tag_name: tag_name, tag_content: tag_content }
     return true

--- a/src/main/miscellaneous.rb
+++ b/src/main/miscellaneous.rb
@@ -294,7 +294,7 @@ module Bot::Miscellaneous
 
     # Skips if message has not reached required cam reacts to be quoted, if it is within a blacklisted channel,
     # if it has been quoted already, or if another message has been quoted within the last 30 seconds already
-    next if camera_reaction.count != (YAML.load_data!("#{MISC_DATA_PATH}/qb_camera_count.yml")[event.channel.id] || 4) ||
+    next if camera_reaction.count < (YAML.load_data!("#{MISC_DATA_PATH}/qb_camera_count.yml")[event.channel.id] || 4) ||
             QUOTEBOARD_BLACKLIST.include?(event.channel.id) ||
             QUOTED_MESSAGES[id: event.message.id] ||
             qb_recent

--- a/src/main/miscellaneous.rb
+++ b/src/main/miscellaneous.rb
@@ -84,7 +84,7 @@ module Bot::Miscellaneous
   reaction_add do |event|
     # Skips unless the message ID is equal to the role button message's ID and user has Member role
     next unless event.message.id == ROLE_MESSAGE_ID &&
-                event.user.role?(MEMBER_ID)
+                event.user.role?(MEMBER_ROLE_ID)
 
     # Cases reaction emoji and gives user correct role accordingly
     case event.emoji.name
@@ -98,7 +98,9 @@ module Bot::Miscellaneous
       event.user.add_role(BOT_GAMES_ROLE_ID)
     when '💭'
       event.user.add_role(VENT_ROLE_ID)
-    when '🗣'
+    when '🗣' # discord has changed the emoji, keep the old ones around for safety
+      event.user.add_role(DEBATE_ROLE_ID)
+    when '🗣️'
       event.user.add_role(DEBATE_ROLE_ID)
     when '🎲'
       event.user.add_role(SANDBOX_ROLE_ID)
@@ -114,19 +116,21 @@ module Bot::Miscellaneous
     # Cases reaction emoji and removes correct role from user accordingly
     case event.emoji.name
     when '🔔'
-      event.user.remove_role(UPDATES_ID)
+      event.user.remove_role(UPDATE_ROLE_ID)
     when '🌟'
-      event.user.remove_role(SVTFOE_NEWS_ID)
+      event.user.remove_role(SVTFOE_NEWS_ROLE_ID)
     when '🚰'
-      event.user.remove_role(SVTFOE_LEAKS_ID)
+      event.user.remove_role(SVTFOE_LEAKS_ROLE_ID)
     when '🎮'
-      event.user.remove_role(BOT_GAMES_ID)
+      event.user.remove_role(BOT_GAMES_ROLE_ID)
     when '💭'
-      event.user.remove_role(VENT_ID)
-    when '🗣'
-      event.user.remove_role(DEBATE_ID)
+      event.user.remove_role(VENT_ROLE_ID)
+    when '🗣' # discord has changed the emoji, keep the old ones around for safety
+      event.user.remove_role(DEBATE_ROLE_ID)
+    when '🗣️'
+      event.user.remove_role(DEBATE_ROLE_ID)      
     when '🎲'
-      event.user.remove_role(SANDBOX_ID)
+      event.user.remove_role(SANDBOX_ROLE_ID)
     end
   end
 


### PR DESCRIPTION
Fix the following bugs:
- tags/custom commands can miss existing instances in the DB due to not performing downcase before query during add thus resulting in a db error
- incorrect ids and out of date emoji is causing the opt-in roles to not work on the main server
- fix potential issue in quoteboard where if a message is dropped it can result in a message never getting quoted even if it is above the necessary count

In addition a validation file for an upcoming auto-updater change was added. In preparation for that, the idea of "dry runs" was added, which executes rake in its entirety, but then bails out right before actually running Cobalt. This is to allow checking that there aren't compile/load-time bugs.